### PR TITLE
Error: The method 'setMockMessageHandler' isn't defined for the class…

### DIFF
--- a/packages/isolate_bloc/lib/src/common/isolate/platform_channel/isolated_platform_channel_middleware.dart
+++ b/packages/isolate_bloc/lib/src/common/isolate/platform_channel/isolated_platform_channel_middleware.dart
@@ -26,7 +26,7 @@ class IsolatedPlatformChannelMiddleware {
 
   void _bindMessageHandlers(List<String> channels) {
     for (final channel in channels) {
-      platformMessenger.setMockMessageHandler(channel, (message) {
+      platformMessenger.setMessageHandler(channel, (message) {
         final completer = Completer<ByteData>();
         final id = generateId();
         _platformResponsesCompleter[id] = completer;


### PR DESCRIPTION
… 'BinaryMessenger'.

Bug threw by the Flutter Debug Console after upgrading to flutter stable channel 2.5.0
../../../Developer/flutter/.pub-cache/hosted/pub.dartlang.org/isolate_bloc-1.0.4/lib/src/common/isolate/platform_channel/isolated_platform_channel_middleware.dart:29:25: Error: The method 'setMockMessageHandler' isn't defined for the class 'BinaryMessenger'.
 - 'BinaryMessenger' is from 'package:flutter/src/services/binary_messenger.dart' ('../../../Developer/flutter/packages/flutter/lib/src/services/binary_messenger.dart').

Try correcting the name to the name of an existing method, or defining a method named 'setMockMessageHandler'.
      platformMessenger.setMockMessageHandler(channel, (message) {
                        ^^^^^^^^^^^^^^^^^^^^^
2

FAILURE: Build failed with an exception.